### PR TITLE
Persist intake data and add back navigation

### DIFF
--- a/Nuform.App/App.xaml
+++ b/Nuform.App/App.xaml
@@ -1,7 +1,9 @@
 <Application x:Class="Nuform.App.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:core="clr-namespace:Nuform.Core;assembly=Nuform.Core"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
+        <core:AppState x:Key="AppState"/>
     </Application.Resources>
 </Application>

--- a/Nuform.App/IntakePage.xaml
+++ b/Nuform.App/IntakePage.xaml
@@ -6,12 +6,12 @@
     <StackPanel Margin="10" VerticalAlignment="Stretch">
         <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
             <TextBlock Text="Estimate #" Width="80" VerticalAlignment="Center"/>
-            <TextBox x:Name="EstimateNumberBox" Width="100"/>
+            <TextBox Width="100" Text="{Binding EstimateNumber}"/>
             <TextBlock Text="Cont %" Margin="20 0 0 0" VerticalAlignment="Center"/>
-            <TextBox x:Name="ContBox" Width="50" Text="5"/>
+            <TextBox Width="50" Text="{Binding ContingencyPercent}"/>
         </StackPanel>
         <TextBlock Text="Rooms" FontWeight="Bold"/>
-        <DataGrid x:Name="RoomsGrid" AutoGenerateColumns="False" Height="120" Margin="0 0 0 10">
+        <DataGrid ItemsSource="{Binding Rooms}" AutoGenerateColumns="False" Height="120" Margin="0 0 0 10">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="L" Binding="{Binding LengthFt}" />
                 <DataGridTextColumn Header="W" Binding="{Binding WidthFt}" />
@@ -24,7 +24,7 @@
             </DataGrid.Columns>
         </DataGrid>
         <TextBlock Text="Openings" FontWeight="Bold"/>
-        <DataGrid x:Name="OpeningsGrid" AutoGenerateColumns="False" Height="120" Margin="0 0 0 10">
+        <DataGrid ItemsSource="{Binding Openings}" AutoGenerateColumns="False" Height="120" Margin="0 0 0 10">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Width" Binding="{Binding WidthFt}" />
                 <DataGridTextColumn Header="Height" Binding="{Binding HeightFt}" />

--- a/Nuform.App/IntakePage.xaml.cs
+++ b/Nuform.App/IntakePage.xaml.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
 using Nuform.Core;
@@ -12,27 +10,17 @@ public partial class IntakePage : Page
     public static CeilingOrientation[] CeilingOrientations { get; } =
         (CeilingOrientation[])System.Enum.GetValues(typeof(CeilingOrientation));
 
-    private ObservableCollection<Room> Rooms { get; } = new();
-    private ObservableCollection<Opening> Openings { get; } = new();
-
     public IntakePage()
     {
         InitializeComponent();
-        RoomsGrid.ItemsSource = Rooms;
-        OpeningsGrid.ItemsSource = Openings;
+        DataContext = new IntakeViewModel();
     }
 
     private void Next_Click(object sender, RoutedEventArgs e)
     {
-        double.TryParse(ContBox.Text, out var contPerc);
-        var input = new EstimateInput
-        {
-            Rooms = Rooms.ToList(),
-            Openings = Openings.ToList(),
-            Options = new EstimateOptions { Contingency = contPerc / 100.0 }
-        };
-        var estimator = new Estimator();
-        var result = estimator.Estimate(input);
-        NavigationService?.Navigate(new ResultsPage(result, EstimateNumberBox.Text));
+        if (DataContext is not IntakeViewModel vm) return;
+        var state = (AppState)Application.Current.FindResource("AppState");
+        state.LoadFrom(vm);
+        NavigationService?.Navigate(new ResultsPage());
     }
 }

--- a/Nuform.App/ResultsPage.xaml
+++ b/Nuform.App/ResultsPage.xaml
@@ -2,22 +2,45 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       Title="Results">
-    <StackPanel Margin="10">
-        <TextBlock Text="Wall Panels" FontWeight="Bold"/>
-        <ItemsControl x:Name="WallPanelsList"/>
-        <TextBlock Text="Ceiling Panels" FontWeight="Bold" Margin="0,10,0,0"/>
-        <ItemsControl x:Name="CeilingPanelsList"/>
-        <TextBlock Text="Trims &amp; Hardware" FontWeight="Bold" Margin="0,10,0,0"/>
-        <ItemsControl x:Name="TrimPartsList"/>
-        <TextBlock x:Name="HardwareText" Margin="0,5,0,0"/>
-        <Button Content="Resolve Server Folders" Margin="0,10,0,0" Click="ResolveFolders_Click"/>
-        <TextBlock x:Name="EstimatePathText" Margin="0,5,0,0"/>
-        <TextBlock x:Name="BomPathText" Margin="0,2,0,0"/>
-        <TextBlock x:Name="PdfPathText" Margin="0,2,0,0"/>
-        <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-            <Button Content="Generate .SOF" Click="GenerateSof_Click" Margin="0,0,5,0"/>
-            <Button Content="Fill &amp; Print Excel" Click="FillPrint_Click" Margin="0,0,5,0"/>
-            <Button Content="Open Folder" Click="OpenFolder_Click"/>
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel>
+            <TextBlock Text="Rooms" FontWeight="Bold"/>
+            <DataGrid x:Name="RoomsSummary" AutoGenerateColumns="False" IsReadOnly="True" Height="100" Margin="0 0 0 10">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="L" Binding="{Binding LengthFt}" />
+                    <DataGridTextColumn Header="W" Binding="{Binding WidthFt}" />
+                    <DataGridTextColumn Header="H" Binding="{Binding HeightFt}" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Text="Openings" FontWeight="Bold"/>
+            <DataGrid x:Name="OpeningsSummary" AutoGenerateColumns="False" IsReadOnly="True" Height="100" Margin="0 0 0 10">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Width" Binding="{Binding WidthFt}" />
+                    <DataGridTextColumn Header="Height" Binding="{Binding HeightFt}" />
+                    <DataGridTextColumn Header="Count" Binding="{Binding Count}" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Text="Wall Panels" FontWeight="Bold"/>
+            <ItemsControl x:Name="WallPanelsList"/>
+            <TextBlock Text="Ceiling Panels" FontWeight="Bold" Margin="0,10,0,0"/>
+            <ItemsControl x:Name="CeilingPanelsList"/>
+            <TextBlock Text="Trims &amp; Hardware" FontWeight="Bold" Margin="0,10,0,0"/>
+            <ItemsControl x:Name="TrimPartsList"/>
+            <TextBlock x:Name="HardwareText" Margin="0,5,0,0"/>
+            <Button Content="Resolve Server Folders" Margin="0,10,0,0" Click="ResolveFolders_Click"/>
+            <TextBlock x:Name="EstimatePathText" Margin="0,5,0,0"/>
+            <TextBlock x:Name="BomPathText" Margin="0,2,0,0"/>
+            <TextBlock x:Name="PdfPathText" Margin="0,2,0,0"/>
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                <Button Content="Generate .SOF" Click="GenerateSof_Click" Margin="0,0,5,0"/>
+                <Button Content="Fill &amp; Print Excel" Click="FillPrint_Click" Margin="0,0,5,0"/>
+                <Button Content="Open Folder" Click="OpenFolder_Click"/>
+            </StackPanel>
         </StackPanel>
-    </StackPanel>
+        <Button Content="Back" HorizontalAlignment="Left" Width="80" Click="Back_Click" Grid.Row="1"/>
+    </Grid>
 </Page>

--- a/Nuform.App/ResultsPage.xaml.cs
+++ b/Nuform.App/ResultsPage.xaml.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -11,24 +10,45 @@ namespace Nuform.App;
 
 public partial class ResultsPage : Page
 {
+    private readonly AppState _state;
     private readonly EstimateResult _result;
-    private readonly string _estimateNumber;
-    public ResultsPage(EstimateResult result, string estimateNumber)
+
+    public ResultsPage()
     {
         InitializeComponent();
-        _result = result;
-        _estimateNumber = estimateNumber;
-        WallPanelsList.ItemsSource = result.WallPanels.Select(kvp => $"{kvp.Value} x {kvp.Key}'");
-        CeilingPanelsList.ItemsSource = result.CeilingPanels.Select(kvp => $"{kvp.Value} x {kvp.Key}'");
-        TrimPartsList.ItemsSource = result.Parts.Select(p => $"{p.PartCode}: {p.QtyPacks} packs ({p.LFNeeded:F1} LF needed, {p.TotalLFProvided:F1} LF provided)");
-        HardwareText.Text = $"Plugs/Spacers: {result.Hardware.PlugSpacerPacks} packs\nExpansion Tools: {result.Hardware.ExpansionTools}\nScrews: {result.Hardware.ScrewBoxes} boxes";
+        _state = (AppState)Application.Current.FindResource("AppState");
+        RoomsSummary.ItemsSource = _state.Rooms;
+        OpeningsSummary.ItemsSource = _state.Openings;
+
+        var estimator = new Estimator();
+        var input = new EstimateInput
+        {
+            Rooms = _state.Rooms.ToList(),
+            Openings = _state.Openings.ToList(),
+            Options = new EstimateOptions { Contingency = (double)_state.ContingencyPercent / 100.0 }
+        };
+        _result = estimator.Estimate(input);
+        WallPanelsList.ItemsSource = _result.WallPanels.Select(kvp => $"{kvp.Value} x {kvp.Key}'");
+        CeilingPanelsList.ItemsSource = _result.CeilingPanels.Select(kvp => $"{kvp.Value} x {kvp.Key}'");
+        TrimPartsList.ItemsSource = _result.Parts.Select(p => $"{p.PartCode}: {p.QtyPacks} packs ({p.LFNeeded:F1} LF needed, {p.TotalLFProvided:F1} LF provided)");
+        HardwareText.Text = $"Plugs/Spacers: {_result.Hardware.PlugSpacerPacks} packs\nExpansion Tools: {_result.Hardware.ExpansionTools}\nScrews: {_result.Hardware.ScrewBoxes} boxes";
+    }
+
+    private void Back_Click(object sender, RoutedEventArgs e)
+    {
+        var intake = new IntakePage();
+        if (intake.DataContext is IntakeViewModel vm)
+        {
+            _state.ApplyTo(vm);
+        }
+        NavigationService?.Navigate(intake);
     }
 
     private void ResolveFolders_Click(object sender, RoutedEventArgs e)
     {
         var cfg = ConfigService.Load();
-        var est = PathDiscovery.FindEstimateFolder(cfg.WipEstimatingRoot, _estimateNumber);
-        var bom = PathDiscovery.FindBomFolder(cfg.WipDesignRoot, _estimateNumber);
+        var est = PathDiscovery.FindEstimateFolder(cfg.WipEstimatingRoot, _state.EstimateNumber);
+        var bom = PathDiscovery.FindBomFolder(cfg.WipDesignRoot, _state.EstimateNumber);
         EstimatePathText.Text = est ?? "Estimate folder not found";
         BomPathText.Text = bom ?? "BOM folder not found";
     }
@@ -47,7 +67,7 @@ public partial class ResultsPage : Page
             return;
         }
 
-        var target = System.IO.Path.Combine(bomCurrent, $"{bomNumber}.sof");
+        var target = Path.Combine(bomCurrent, $"{bomNumber}.sof");
         var header = new SofHeader { Date = DateTime.Today, ShipTo = "SoldTo", FreightBy = "Nuform" };
         try
         {
@@ -63,11 +83,11 @@ public partial class ResultsPage : Page
     private void FillPrint_Click(object sender, RoutedEventArgs e)
     {
         var cfg = ConfigService.Load();
-        var est = PathDiscovery.FindEstimateFolder(cfg.WipEstimatingRoot, _estimateNumber);
+        var est = PathDiscovery.FindEstimateFolder(cfg.WipEstimatingRoot, _state.EstimateNumber);
         if (est == null) { MessageBox.Show("Estimate folder not found"); return; }
         try
         {
-            var pdf = ExcelService.FillAndPrint(cfg, _estimateNumber, _result, Path.Combine(est, "ESTIMATE"));
+            var pdf = ExcelService.FillAndPrint(cfg, _state.EstimateNumber, _result, Path.Combine(est, "ESTIMATE"));
             PdfPathText.Text = pdf;
             Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{pdf}\"") { UseShellExecute = true });
         }

--- a/Nuform.Core/AppState.cs
+++ b/Nuform.Core/AppState.cs
@@ -1,0 +1,35 @@
+using System.Collections.ObjectModel;
+
+namespace Nuform.Core;
+
+public class AppState
+{
+    public string EstimateNumber { get; set; } = "";
+    public decimal ContingencyPercent { get; set; }
+    public ObservableCollection<Room> Rooms { get; } = new();
+    public ObservableCollection<Opening> Openings { get; } = new();
+
+    public void LoadFrom(IntakeViewModel vm)
+    {
+        EstimateNumber = vm.EstimateNumber;
+        ContingencyPercent = vm.ContingencyPercent;
+        Rooms.Clear();
+        foreach (var r in vm.Rooms)
+            Rooms.Add(r);
+        Openings.Clear();
+        foreach (var o in vm.Openings)
+            Openings.Add(o);
+    }
+
+    public void ApplyTo(IntakeViewModel vm)
+    {
+        vm.EstimateNumber = EstimateNumber;
+        vm.ContingencyPercent = ContingencyPercent;
+        vm.Rooms.Clear();
+        foreach (var r in Rooms)
+            vm.Rooms.Add(r);
+        vm.Openings.Clear();
+        foreach (var o in Openings)
+            vm.Openings.Add(o);
+    }
+}

--- a/Nuform.Core/IntakeViewModel.cs
+++ b/Nuform.Core/IntakeViewModel.cs
@@ -1,0 +1,11 @@
+using System.Collections.ObjectModel;
+
+namespace Nuform.Core;
+
+public class IntakeViewModel
+{
+    public string EstimateNumber { get; set; } = "";
+    public decimal ContingencyPercent { get; set; }
+    public ObservableCollection<Room> Rooms { get; } = new();
+    public ObservableCollection<Opening> Openings { get; } = new();
+}


### PR DESCRIPTION
## Summary
- Persist intake entries in a new `AppState` singleton to allow navigation back from results without losing data
- Bind `IntakePage` to an `IntakeViewModel` and store state before moving to results
- Load data from `AppState` on `ResultsPage`, show room/opening summaries, and add a Back button

## Testing
- `dotnet build` *(fails: The imported project Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f886034f08322b914fd31f09ad433