### PR TITLE
Add legacy compatibility models for estimator app

### DIFF
--- a/Nuform.App/ExcelService.cs
+++ b/Nuform.App/ExcelService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using Nuform.Core;
+using Nuform.Core.LegacyCompat;
 
 namespace Nuform.App;
 

--- a/Nuform.App/IntakePage.xaml.cs
+++ b/Nuform.App/IntakePage.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using Nuform.Core;
 using Nuform.Core.Domain;
+using Nuform.Core.LegacyCompat;
 using Nuform.App.Views;
 using Nuform.App.ViewModels;
 

--- a/Nuform.App/SofGenerator.cs
+++ b/Nuform.App/SofGenerator.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Nuform.Core;
+using Nuform.Core.LegacyCompat;
 
 namespace Nuform.App;
 

--- a/Nuform.Core/LegacyCompat/AppConfig.cs
+++ b/Nuform.Core/LegacyCompat/AppConfig.cs
@@ -1,0 +1,9 @@
+namespace Nuform.Core.LegacyCompat;
+
+public class AppConfig
+{
+    public string WipEstimatingRoot { get; set; } = "I:/CF QUOTES/WIP Estimating";
+    public string WipDesignRoot { get; set; } = "I:/CF QUOTES/WIP Design";
+    public string PdfPrinter { get; set; } = "Microsoft Print to PDF";
+    public string ExcelTemplatePath { get; set; } = @"C:\\Templates\\Estimating Template.xlsm";
+}

--- a/Nuform.Core/LegacyCompat/CatalogItem.cs
+++ b/Nuform.Core/LegacyCompat/CatalogItem.cs
@@ -1,0 +1,13 @@
+namespace Nuform.Core.LegacyCompat;
+
+public class CatalogItem
+{
+    public string PartCode { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Unit { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public int PackPieces { get; set; }
+    public decimal LengthFt { get; set; }
+    public string Color { get; set; } = string.Empty;
+    public decimal PriceUSD { get; set; }
+}

--- a/Nuform.Core/LegacyCompat/CatalogService.cs
+++ b/Nuform.Core/LegacyCompat/CatalogService.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
+using Nuform.Core.Services;
+
+namespace Nuform.Core.LegacyCompat;
+
+public static class CatalogService
+{
+    public static IReadOnlyList<CatalogItem> Load(string? _)
+    {
+        var svc = new Nuform.Core.Services.CatalogService();
+        return svc.GetAll().Values.Select(p => new CatalogItem
+        {
+            PartCode = p.PartNumber,
+            Description = p.Description,
+            Unit = p.Units,
+            Category = p.Category,
+            PackPieces = p.PackPieces,
+            LengthFt = (decimal)p.LengthFt,
+            Color = p.Color,
+            PriceUSD = 0m
+        }).ToList();
+    }
+}

--- a/Nuform.Core/LegacyCompat/CeilingOrientation.cs
+++ b/Nuform.Core/LegacyCompat/CeilingOrientation.cs
@@ -1,0 +1,7 @@
+namespace Nuform.Core.LegacyCompat;
+
+public enum CeilingOrientation
+{
+    Widthwise,
+    Lengthwise
+}

--- a/Nuform.Core/LegacyCompat/EstimateResult.cs
+++ b/Nuform.Core/LegacyCompat/EstimateResult.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace Nuform.Core.LegacyCompat;
+
+public class EstimateResult
+{
+    public int BasePanels { get; set; }
+    public int RoundedPanels { get; set; }
+    public decimal OveragePercentRounded { get; set; }
+    public bool WarnOverage { get; set; }
+    public decimal ExtrasPercent { get; set; }
+    public Dictionary<double, int> WallPanels { get; set; } = new();
+    public Dictionary<double, int> CeilingPanels { get; set; } = new();
+    public List<Room> Rooms { get; set; } = new();
+    public HardwareResult Hardware { get; set; } = new();
+    public List<BomLine> Parts { get; set; } = new();
+}
+
+public class BomLine
+{
+    public string PartCode { get; set; } = string.Empty;
+    public int QtyPacks { get; set; }
+    public double LFNeeded { get; set; }
+}
+
+public class HardwareResult
+{
+    public int PlugSpacerPacks { get; set; }
+    public int ExpansionTools { get; set; }
+    public int ScrewBoxes { get; set; }
+    public int WallScrewBoxes { get; set; }
+    public int CeilingScrewBoxes { get; set; }
+}

--- a/Nuform.Core/LegacyCompat/FileNaming.cs
+++ b/Nuform.Core/LegacyCompat/FileNaming.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Nuform.Core.LegacyCompat;
+
+public class FileNamingResult
+{
+    public string? ServerDrawingsPath { get; set; }
+    public string? ServerEstimatePath { get; set; }
+    public string? ServerInvoicingPath { get; set; }
+    public string? ServerCurrentPath { get; set; }
+    public string? DesktopDrawingsPath { get; set; }
+    public string? DesktopEstimatePath { get; set; }
+    public string? DesktopInvoicingPath { get; set; }
+    public string? DesktopCurrentPath { get; set; }
+    public string EstimatePdfName { get; set; } = string.Empty;
+    public string DrawingPdfName { get; set; } = string.Empty;
+    public string EmailPdfName { get; set; } = string.Empty;
+    public string? SofName { get; set; }
+}
+
+public static class FileNaming
+{
+    public static FileNamingResult Build(string estimateNumber, IEnumerable<string>? monikers,
+        string? bomNumber, string? estimateRangeFolder, string? bomRangeFolder)
+    {
+        var monik = monikers != null ? string.Concat(monikers) : string.Empty;
+        var baseName = estimateNumber + monik;
+        var desktopBase = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory), baseName);
+        return new FileNamingResult
+        {
+            EstimatePdfName = baseName + ".pdf",
+            DrawingPdfName = baseName + " - Drawing.pdf",
+            EmailPdfName = baseName + " - Email 1.pdf",
+            SofName = bomNumber != null ? bomNumber + ".sof" : null,
+            ServerDrawingsPath = estimateRangeFolder != null ? Path.Combine(estimateRangeFolder, estimateNumber, "DRAWINGS") : null,
+            ServerEstimatePath = estimateRangeFolder != null ? Path.Combine(estimateRangeFolder, estimateNumber, "ESTIMATE") : null,
+            ServerInvoicingPath = estimateRangeFolder != null ? Path.Combine(estimateRangeFolder, estimateNumber, "INVOICING") : null,
+            ServerCurrentPath = bomRangeFolder != null && bomNumber != null ? Path.Combine(bomRangeFolder, bomNumber, "1-CURRENT") : null,
+            DesktopDrawingsPath = Path.Combine(desktopBase, "DRAWINGS"),
+            DesktopEstimatePath = Path.Combine(desktopBase, "ESTIMATE"),
+            DesktopInvoicingPath = Path.Combine(desktopBase, "INVOICING"),
+            DesktopCurrentPath = bomNumber != null ? Path.Combine(desktopBase, bomNumber, "1-CURRENT") : null
+        };
+    }
+}

--- a/Nuform.Core/LegacyCompat/Room.cs
+++ b/Nuform.Core/LegacyCompat/Room.cs
@@ -1,0 +1,13 @@
+namespace Nuform.Core.LegacyCompat;
+
+public class Room
+{
+    public double LengthFt { get; set; }
+    public double WidthFt { get; set; }
+    public double HeightFt { get; set; }
+    public double WallPanelLengthFt { get; set; }
+    public double PanelWidthInches { get; set; } = 12;
+    public bool HasCeiling { get; set; }
+    public double CeilingPanelLengthFt { get; set; }
+    public CeilingOrientation CeilingOrientation { get; set; } = CeilingOrientation.Lengthwise;
+}


### PR DESCRIPTION
## Summary
- restore legacy models in Nuform.Core.LegacyCompat for AppConfig, EstimateResult, CatalogItem, Room and CeilingOrientation
- add adapters for FileNaming and CatalogService to serve existing export code
- update ExcelService, IntakePage and SofGenerator to use the compat namespace

## Testing
- `dotnet build NuformEstimator.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test Nuform.Tests/Nuform.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a77b0833308322be70a92c2a92904a