### PR TITLE
Remove legacy path checks and unused PropertyChanged event

### DIFF
--- a/Nuform.App/ViewModels/CalculationsViewModel.cs
+++ b/Nuform.App/ViewModels/CalculationsViewModel.cs
@@ -1,10 +1,9 @@
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using Nuform.Core.Domain;
 
 namespace Nuform.App.ViewModels;
 
-public sealed class CalculationsViewModel : INotifyPropertyChanged
+public sealed class CalculationsViewModel
 {
     public ObservableCollection<FormulaRow> FormulaRows { get; } = new();
 
@@ -52,6 +51,4 @@ public sealed class CalculationsViewModel : INotifyPropertyChanged
             }
         }
     }
-
-    public event PropertyChangedEventHandler? PropertyChanged;
 }


### PR DESCRIPTION
## Summary
- replace CAS-based PathDiscovery checks with simple directory creation and write probe
- drop unused `PropertyChanged` event from `CalculationsViewModel`

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop)*
- `dotnet run --project Nuform.App -p:EnableWindowsTargeting=true` *(build failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8aed39df483228cd9cef635e8b430