### PR TITLE
Restore compat config and estimate result models for SOF generation

### DIFF
--- a/Nuform.App/SofGenerator.cs
+++ b/Nuform.App/SofGenerator.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Nuform.Core;
+using Nuform.Core.LegacyCompat;
 
 namespace Nuform.App;
 

--- a/Nuform.Core/LegacyCompat/AppConfig.cs
+++ b/Nuform.Core/LegacyCompat/AppConfig.cs
@@ -1,9 +1,18 @@
 namespace Nuform.Core.LegacyCompat;
 
-public class AppConfig
+/// <summary>
+/// Compatibility application configuration used by legacy helpers.
+/// Internal note listing referenced members:
+/// - <see cref="WipEstimatingRoot"/> : string
+/// - <see cref="WipDesignRoot"/> : string
+/// - <see cref="PdfPrinter"/> : string
+/// - <see cref="ExcelTemplatePath"/> : string
+/// </summary>
+public sealed class AppConfig
 {
     public string WipEstimatingRoot { get; set; } = "I:/CF QUOTES/WIP Estimating";
     public string WipDesignRoot { get; set; } = "I:/CF QUOTES/WIP Design";
     public string PdfPrinter { get; set; } = "Microsoft Print to PDF";
-    public string ExcelTemplatePath { get; set; } = @"C:\\Templates\\Estimating Template.xlsm";
+    public string ExcelTemplatePath { get; set; } = @"C:\Templates\Estimating Template.xlsm";
 }
+

--- a/Nuform.Core/LegacyCompat/EstimateResult.cs
+++ b/Nuform.Core/LegacyCompat/EstimateResult.cs
@@ -2,28 +2,37 @@ using System.Collections.Generic;
 
 namespace Nuform.Core.LegacyCompat;
 
-public class EstimateResult
+/// <summary>
+/// Compatibility estimate output used by legacy utilities.
+/// Internal note of referenced members:
+/// - <see cref="WallPanels"/> : Dictionary&lt;double,int&gt;
+/// - <see cref="CeilingPanels"/> : Dictionary&lt;double,int&gt;
+/// - <see cref="Trims"/> : <see cref="TrimResult"/>
+/// - <see cref="Hardware"/> : <see cref="HardwareResult"/>
+/// - <see cref="Parts"/> : List&lt;<see cref="PartRequirement"/>&gt;
+/// - <see cref="Rooms"/> : List&lt;<see cref="Room"/>&gt;
+/// </summary>
+public sealed class EstimateResult
 {
-    public int BasePanels { get; set; }
-    public int RoundedPanels { get; set; }
-    public decimal OveragePercentRounded { get; set; }
-    public bool WarnOverage { get; set; }
-    public decimal ExtrasPercent { get; set; }
     public Dictionary<double, int> WallPanels { get; set; } = new();
     public Dictionary<double, int> CeilingPanels { get; set; } = new();
-    public List<Room> Rooms { get; set; } = new();
+    public TrimResult Trims { get; set; } = new();
     public HardwareResult Hardware { get; set; } = new();
-    public List<BomLine> Parts { get; set; } = new();
+    public List<PartRequirement> Parts { get; set; } = new();
+    public List<Room> Rooms { get; set; } = new();
 }
 
-public class BomLine
+public sealed class TrimResult
 {
-    public string PartCode { get; set; } = string.Empty;
-    public int QtyPacks { get; set; }
-    public double LFNeeded { get; set; }
+    public int JTrimPacks { get; set; }
+    public int JTrimPackLenFt { get; set; }
+    public int CornerPacks { get; set; }
+    public int CornerPackLenFt { get; set; }
+    public int CrownBasePairs { get; set; }
+    public int TopTrackPackLenFt { get; set; }
 }
 
-public class HardwareResult
+public sealed class HardwareResult
 {
     public int PlugSpacerPacks { get; set; }
     public int ExpansionTools { get; set; }
@@ -31,3 +40,11 @@ public class HardwareResult
     public int WallScrewBoxes { get; set; }
     public int CeilingScrewBoxes { get; set; }
 }
+
+public sealed class PartRequirement
+{
+    public string PartCode { get; set; } = string.Empty;
+    public int QtyPacks { get; set; }
+    public double LFNeeded { get; set; }
+}
+


### PR DESCRIPTION
## Summary
- add sealed legacy AppConfig with required fields
- define legacy EstimateResult with trims, hardware, and parts
- reference LegacyCompat models in SofGenerator

## Testing
- `dotnet build Nuform.Core/Nuform.Core.csproj -c Release`
- `dotnet build -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b9dbdef0832280005a18eb2f1eba