### PR TITLE
Add MigraDocCore packages to Nuform.App

### DIFF
--- a/Nuform.App/Nuform.App.csproj
+++ b/Nuform.App/Nuform.App.csproj
@@ -12,8 +12,8 @@
 
    <ItemGroup>
         <PackageReference Include="Microsoft.Office.Interop.Excel" Version="15.0.4795.1001" />
-        <PackageReference Include="PdfSharpCore" Version="1.3.31" />
-        <PackageReference Include="MigraDocCore.DocumentObjectModel" Version="1.3.1" />
-        <PackageReference Include="MigraDocCore.Rendering" Version="1.3.1" />
+        <PackageReference Include="PdfSharpCore" Version="1.3.48" />
+        <PackageReference Include="MigraDocCore.DocumentObjectModel" Version="1.3.48" />
+        <PackageReference Include="MigraDocCore.Rendering" Version="1.3.48" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- update Nuform.App package references for PdfSharpCore and MigraDocCore packages to version 1.3.48

## Testing
- `dotnet build` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*
- `dotnet test Nuform.Tests/Nuform.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a8d467e5fc8322ba5ff52c8f2faa4a