### PR TITLE
Fix EstimateState type conflicts in Nuform.App

### DIFF
--- a/Nuform.App/ViewModels/CalculationsViewModel.cs
+++ b/Nuform.App/ViewModels/CalculationsViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Nuform.Core.Domain;
+using CoreEstimateState = Nuform.Core.Domain.EstimateState;
 
 namespace Nuform.App.ViewModels;
 
@@ -13,10 +14,10 @@ public sealed class CalculationsViewModel : INotifyPropertyChanged
 
     public ObservableCollection<FormulaRow> Rows { get; } = new();
 
-    private readonly EstimateState _state;
+    private readonly CoreEstimateState _state;
     private CalcEstimateResult _last;
 
-    public CalculationsViewModel(EstimateState state)
+    public CalculationsViewModel(CoreEstimateState state)
     {
         _state = state;
         _last = CalcService.CalcEstimate(_state.Input);

--- a/Nuform.App/Views/ResultsPage.xaml.cs
+++ b/Nuform.App/Views/ResultsPage.xaml.cs
@@ -2,9 +2,6 @@ using System.Windows.Controls;
 using Nuform.App.ViewModels;
 using CoreEstimateState = Nuform.Core.Domain.EstimateState;
 
-// Alias the Core type so there’s no ambiguity
-using CoreEstimateState = Nuform.Core.Domain.EstimateState;
-
 namespace Nuform.App.Views
 {
     public partial class ResultsPage : Page


### PR DESCRIPTION
## Summary
- alias `Nuform.Core.Domain.EstimateState` as `CoreEstimateState` to avoid type conflicts
- update view models and pages to use `CoreEstimateState`

## Testing
- `dotnet restore`
- `dotnet build NuformEstimator.sln -c Debug` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet run --project Nuform.App` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8993e9c08322a4dc734777225b25