### PR TITLE
Use viewmodel EstimateState in app

### DIFF
--- a/Nuform.App/IntakePage.xaml.cs
+++ b/Nuform.App/IntakePage.xaml.cs
@@ -5,8 +5,7 @@ using System.Windows.Controls;
 using Nuform.Core;
 using Nuform.Core.Domain;
 using Nuform.Core.LegacyCompat;
-// NOTE: Do NOT import Nuform.App.ViewModels here; it creates name collisions.
-// using Nuform.App.ViewModels;
+using Nuform.App.ViewModels;
 
 namespace Nuform.App
 {
@@ -21,6 +20,7 @@ namespace Nuform.App
 
         private ObservableCollection<Room> Rooms { get; } = new();
         private ObservableCollection<OpeningInput> Openings { get; } = new();
+        private readonly EstimateState _state = new();
 
         public IntakePage()
         {
@@ -66,15 +66,11 @@ namespace Nuform.App
                 CeilingPanelColor = "NUFORM WHITE"
             };
 
-            var result = CalcService.CalcEstimate(input);
-            var state = new Nuform.Core.Domain.EstimateState
-            {
-                Input = input,
-                Result = result
-            };
+            _state.Input = input;
+            _state.Result = CalcService.CalcEstimate(input);
 
             // Navigate to results page
-            NavigationService?.Navigate(new Nuform.App.Views.ResultsPage(state));
+            NavigationService?.Navigate(new Nuform.App.Views.ResultsPage(_state));
         }
 
         private string? GetSelectedTransition()

--- a/Nuform.App/ViewModels/CalculationsViewModel.cs
+++ b/Nuform.App/ViewModels/CalculationsViewModel.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Nuform.Core.Domain;
-using CoreEstimateState = Nuform.Core.Domain.EstimateState;
 
 namespace Nuform.App.ViewModels;
 
@@ -14,10 +13,10 @@ public sealed class CalculationsViewModel : INotifyPropertyChanged
 
     public ObservableCollection<FormulaRow> Rows { get; } = new();
 
-    private readonly CoreEstimateState _state;
+    private readonly EstimateState _state;
     private CalcEstimateResult _last;
 
-    public CalculationsViewModel(CoreEstimateState state)
+    public CalculationsViewModel(EstimateState state)
     {
         _state = state;
         _last = CalcService.CalcEstimate(_state.Input);

--- a/Nuform.App/ViewModels/EstimateState.cs
+++ b/Nuform.App/ViewModels/EstimateState.cs
@@ -1,0 +1,14 @@
+using System;
+using Nuform.Core.Domain;
+
+namespace Nuform.App.ViewModels
+{
+    public class EstimateState
+    {
+        public BuildingInput Input { get; set; } = new();
+        public CalcEstimateResult Result { get; set; } = new();
+        public event Action? Updated;
+        public void RaiseUpdated() => Updated?.Invoke();
+    }
+}
+

--- a/Nuform.App/ViewModels/ResultsViewModel.cs
+++ b/Nuform.App/ViewModels/ResultsViewModel.cs
@@ -9,20 +9,19 @@ using Nuform.Core.Services;
 using Nuform.App.Models;
 using Nuform.App.Services;
 using Nuform.App.Views;
-using CoreEstimateState = Nuform.Core.Domain.EstimateState;
 
 namespace Nuform.App.ViewModels
 {
     public sealed class ResultsViewModel : INotifyPropertyChanged
     {
-        public CoreEstimateState State { get; }
+        public EstimateState State { get; }
         private readonly CatalogService _catalog = new();
         private bool _catalogError;
 
         private decimal _extrasPercent;
         private string _extrasPercentText = "5";
 
-        public ResultsViewModel(CoreEstimateState state)
+        public ResultsViewModel(EstimateState state)
         {
             State = state ?? throw new ArgumentNullException(nameof(state));
 

--- a/Nuform.App/Views/ResultsPage.xaml.cs
+++ b/Nuform.App/Views/ResultsPage.xaml.cs
@@ -1,12 +1,11 @@
 using System.Windows.Controls;
 using Nuform.App.ViewModels;
-using CoreEstimateState = Nuform.Core.Domain.EstimateState;
 
 namespace Nuform.App.Views
 {
     public partial class ResultsPage : Page
     {
-        public ResultsPage(CoreEstimateState state)
+        public ResultsPage(EstimateState state)
         {
             InitializeComponent();
             DataContext = new ResultsViewModel(state);


### PR DESCRIPTION
## Summary
- add app-level EstimateState with Input, Result and update notifications
- use viewmodel EstimateState across Intake, Results, and Calculations

## Testing
- `dotnet restore`
- `dotnet build NuformEstimator.sln -c Debug` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*
- `dotnet run --project Nuform.App/Nuform.App.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8ca959e4832292dc336dc3ac31db