### PR TITLE
Add panel code resolver and room color selection

### DIFF
--- a/Nuform.App/IntakePage.xaml
+++ b/Nuform.App/IntakePage.xaml
@@ -19,9 +19,11 @@
                 <DataGridTextColumn Header="H" Binding="{Binding HeightFt}" />
                 <DataGridTextColumn Header="WallPanelLen" Binding="{Binding WallPanelLengthFt}" />
                 <DataGridComboBoxColumn Header="PanelWidth" SelectedItemBinding="{Binding PanelWidthInches}" ItemsSource="{x:Static local:IntakePage.PanelWidths}" />
+                <DataGridComboBoxColumn Header="WallColor" SelectedItemBinding="{Binding WallPanelColor}" ItemsSource="{x:Static local:IntakePage.PanelColors}" />
                 <DataGridCheckBoxColumn Header="Ceiling" Binding="{Binding HasCeiling}" />
                 <DataGridTextColumn Header="CeilingLen" Binding="{Binding CeilingPanelLengthFt}" />
                 <DataGridComboBoxColumn Header="Orientation" SelectedItemBinding="{Binding CeilingOrientation}" ItemsSource="{x:Static local:IntakePage.CeilingOrientations}" />
+                <DataGridComboBoxColumn Header="CeilColor" SelectedItemBinding="{Binding CeilingPanelColor}" ItemsSource="{x:Static local:IntakePage.PanelColors}" />
             </DataGrid.Columns>
         </DataGrid>
         <TextBlock Text="Openings" FontWeight="Bold"/>

--- a/Nuform.App/IntakePage.xaml.cs
+++ b/Nuform.App/IntakePage.xaml.cs
@@ -16,6 +16,9 @@ namespace Nuform.App
         public static CeilingOrientation[] CeilingOrientations { get; } =
             (CeilingOrientation[])System.Enum.GetValues(typeof(CeilingOrientation));
 
+        public static NuformColor[] PanelColors { get; } =
+            (NuformColor[])System.Enum.GetValues(typeof(NuformColor));
+
         public static OpeningTreatment[] OpeningTreatments { get; } =
             (OpeningTreatment[])System.Enum.GetValues(typeof(OpeningTreatment));
 
@@ -61,11 +64,11 @@ namespace Nuform.App
                 WallPanelSeries = "R3",
                 WallPanelWidthInches = (int)room.PanelWidthInches,
                 WallPanelLengthFt = (decimal)room.WallPanelLengthFt,
-                WallPanelColor = "NUFORM WHITE",
+                WallPanelColor = PanelCodeResolver.ColorName(room.WallPanelColor),
                 CeilingPanelSeries = "R3",
                 CeilingPanelWidthInches = (int)room.PanelWidthInches,
                 CeilingPanelLengthFt = (decimal)room.CeilingPanelLengthFt,
-                CeilingPanelColor = "NUFORM WHITE",
+                CeilingPanelColor = PanelCodeResolver.ColorName(room.CeilingPanelColor),
                 IncludeWallScrews = _state.Input.IncludeWallScrews,
                 IncludeCeilingScrews = _state.Input.IncludeCeilingScrews,
                 IncludePlugs = _state.Input.IncludePlugs,

--- a/Nuform.Core/Domain/PanelCodeResolver.cs
+++ b/Nuform.Core/Domain/PanelCodeResolver.cs
@@ -1,0 +1,57 @@
+namespace Nuform.Core.Domain
+{
+    public enum NuformColor { BrightWhite, NuformWhite, Black, Gray, Tan }
+
+    public static class PanelCodeResolver
+    {
+        // Length → letter in Nuform catalog
+        public static string LengthLetter(int lengthFt) => lengthFt switch
+        {
+            10 => "B", 12 => "C", 14 => "D", 16 => "E", 18 => "F", 20 => "G",
+            _  => throw new ArgumentOutOfRangeException(nameof(lengthFt))
+        };
+
+        public static string ColorSuffix(NuformColor color) => color switch
+        {
+            NuformColor.BrightWhite => "BW",
+            NuformColor.NuformWhite => "WH",
+            NuformColor.Black       => "BK",
+            NuformColor.Gray        => "GA",
+            NuformColor.Tan         => "TN",
+            _ => "WH"
+        };
+
+        public static (string code, string name) PanelSku(int widthInches, int lengthFt, NuformColor color)
+        {
+            var L = LengthLetter(lengthFt);
+            var C = ColorSuffix(color);
+            if (widthInches == 18)
+            {
+                // RELINE PRO 18"
+                return ($"GELPRO{L}A{C}", $"RELINE PRO 18\" Panel ({color}) {lengthFt}′");
+            }
+            // R3 12"
+            return ($"GEL2PL{L}A{C}", $"RELINE R3 12\" Panel ({color}) {lengthFt}′");
+        }
+
+        public static NuformColor ParseColor(string color) => color.ToUpperInvariant() switch
+        {
+            "BRIGHT WHITE" => NuformColor.BrightWhite,
+            "NUFORM WHITE" => NuformColor.NuformWhite,
+            "BLACK" => NuformColor.Black,
+            "GRAY" => NuformColor.Gray,
+            "TAN" => NuformColor.Tan,
+            _ => NuformColor.NuformWhite
+        };
+
+        public static string ColorName(NuformColor color) => color switch
+        {
+            NuformColor.BrightWhite => "BRIGHT WHITE",
+            NuformColor.NuformWhite => "NUFORM WHITE",
+            NuformColor.Black       => "BLACK",
+            NuformColor.Gray        => "GRAY",
+            NuformColor.Tan         => "TAN",
+            _ => "NUFORM WHITE"
+        };
+    }
+}

--- a/Nuform.Core/LegacyCompat/Room.cs
+++ b/Nuform.Core/LegacyCompat/Room.cs
@@ -10,4 +10,8 @@ public class Room
     public bool HasCeiling { get; set; }
     public double CeilingPanelLengthFt { get; set; }
     public CeilingOrientation CeilingOrientation { get; set; } = CeilingOrientation.Lengthwise;
+
+    // Per-room panel colors
+    public Nuform.Core.Domain.NuformColor WallPanelColor { get; set; } = Nuform.Core.Domain.NuformColor.NuformWhite;
+    public Nuform.Core.Domain.NuformColor CeilingPanelColor { get; set; } = Nuform.Core.Domain.NuformColor.NuformWhite;
 }

--- a/Nuform.Core/Services/BomService.cs
+++ b/Nuform.Core/Services/BomService.cs
@@ -26,18 +26,23 @@ public static class BomService
         decimal wallPanelLf = 0m;
         decimal ceilingPanelLf = 0m;
 
-        // Wall panels
+        // Wall panels using resolver
         try
         {
-            var wallPanelSpec = catalog.FindPanel(
-                input.WallPanelSeries,
-                input.WallPanelColor,
-                (int)input.WallPanelLengthFt);
-            if (wallPanelSpec == null) throw new InvalidOperationException();
-            Add(wallPanelSpec, result.Panels.RoundedPanels, "Panels");
-            wallPanelLf = result.Panels.RoundedPanels * (decimal)wallPanelSpec.LengthFt;
+            var color = PanelCodeResolver.ParseColor(input.WallPanelColor);
+            var (code, name) = PanelCodeResolver.PanelSku(input.WallPanelWidthInches, (int)input.WallPanelLengthFt, color);
+            var spec = new PartSpec
+            {
+                PartNumber = code,
+                Description = name,
+                Units = "PCS",
+                LengthFt = (int)input.WallPanelLengthFt,
+                Category = "Panels"
+            };
+            Add(spec, result.Panels.RoundedPanels, "Panels");
+            wallPanelLf = result.Panels.RoundedPanels * (decimal)spec.LengthFt;
         }
-        catch (InvalidOperationException)
+        catch (Exception)
         {
             missing = true;
             Console.Error.WriteLine("Missing panel specification");
@@ -56,15 +61,20 @@ public static class BomService
 
             try
             {
-                var ceilSpec = catalog.FindPanel(
-                    input.CeilingPanelSeries,
-                    input.CeilingPanelColor,
-                    (int)input.CeilingPanelLengthFt);
-                if (ceilSpec == null) throw new InvalidOperationException();
-                Add(ceilSpec, roundedCeiling, "Panels");
-                ceilingPanelLf = roundedCeiling * (decimal)ceilSpec.LengthFt;
+                var color = PanelCodeResolver.ParseColor(input.CeilingPanelColor);
+                var (code, name) = PanelCodeResolver.PanelSku(input.CeilingPanelWidthInches, (int)input.CeilingPanelLengthFt, color);
+                var spec = new PartSpec
+                {
+                    PartNumber = code,
+                    Description = name,
+                    Units = "PCS",
+                    LengthFt = (int)input.CeilingPanelLengthFt,
+                    Category = "Panels"
+                };
+                Add(spec, roundedCeiling, "Panels");
+                ceilingPanelLf = roundedCeiling * (decimal)spec.LengthFt;
             }
-            catch (InvalidOperationException)
+            catch (Exception)
             {
                 missing = true;
                 Console.Error.WriteLine("Missing ceiling panel specification");


### PR DESCRIPTION
## Summary
- add `PanelCodeResolver` to generate panel SKUs and human-readable names
- allow selecting wall and ceiling panel colors per room and carry them into estimates
- generate panel BOM lines using real codes and names derived from width, length and color

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68acbf4931bc8322838ca21086e290c2