### PR TITLE
Fix enum namespace collisions in app

### DIFF
--- a/Nuform.App/ExcelService.cs
+++ b/Nuform.App/ExcelService.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using Nuform.Core;
-using Nuform.Core.LegacyCompat;
 
 namespace Nuform.App;
 

--- a/Nuform.App/IntakePage.xaml.cs
+++ b/Nuform.App/IntakePage.xaml.cs
@@ -4,23 +4,25 @@ using System.Windows;
 using System.Windows.Controls;
 using Nuform.Core;
 using Nuform.Core.Domain;
-using Nuform.Core.LegacyCompat;
 using Nuform.App.ViewModels;
 using VmEstimateState = Nuform.App.ViewModels.EstimateState;
+using DomainCeilingOrientation = Nuform.Core.Domain.CeilingOrientation;
+using DomainOpeningTreatment   = Nuform.Core.Domain.OpeningTreatment;
+using DomainNuformColor        = Nuform.Core.Domain.NuformColor;
 
 namespace Nuform.App
 {
     public partial class IntakePage : Page
     {
         public static double[] PanelWidths { get; } = new[] { 12.0, 18.0 };
-        public static CeilingOrientation[] CeilingOrientations { get; } =
-            (CeilingOrientation[])System.Enum.GetValues(typeof(CeilingOrientation));
+        public static DomainCeilingOrientation[] CeilingOrientations { get; } =
+            (DomainCeilingOrientation[])System.Enum.GetValues(typeof(DomainCeilingOrientation));
 
-        public static NuformColor[] PanelColors { get; } =
-            (NuformColor[])System.Enum.GetValues(typeof(NuformColor));
+        public static DomainNuformColor[] PanelColors { get; } =
+            (DomainNuformColor[])System.Enum.GetValues(typeof(DomainNuformColor));
 
-        public static OpeningTreatment[] OpeningTreatments { get; } =
-            (OpeningTreatment[])System.Enum.GetValues(typeof(OpeningTreatment));
+        public static DomainOpeningTreatment[] OpeningTreatments { get; } =
+            (DomainOpeningTreatment[])System.Enum.GetValues(typeof(DomainOpeningTreatment));
 
         private ObservableCollection<Room> Rooms { get; } = new();
         private ObservableCollection<OpeningInput> Openings { get; } = new();

--- a/Nuform.App/SofGenerator.cs
+++ b/Nuform.App/SofGenerator.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Nuform.Core;
-using Nuform.Core.LegacyCompat;
 
 namespace Nuform.App;
 

--- a/Nuform.App/ViewModels/ResultsViewModel.cs
+++ b/Nuform.App/ViewModels/ResultsViewModel.cs
@@ -10,19 +10,20 @@ using Nuform.Core.Services;
 using Nuform.App.Models;
 using Nuform.App.Services;
 using Nuform.App.Views;
+using VmEstimateState = Nuform.App.ViewModels.EstimateState;
 
 namespace Nuform.App.ViewModels
 {
     public sealed class ResultsViewModel : INotifyPropertyChanged
     {
-        public EstimateState State { get; }
+        public VmEstimateState State { get; }
         private readonly CatalogService _catalog = new();
         private bool _catalogError;
 
         private decimal _extrasPercent;
         private string _extrasPercentText = "5";
 
-        public ResultsViewModel(EstimateState state)
+        public ResultsViewModel(VmEstimateState state)
         {
             State = state ?? throw new ArgumentNullException(nameof(state));
 

--- a/Nuform.App/Views/ResultsPage.xaml.cs
+++ b/Nuform.App/Views/ResultsPage.xaml.cs
@@ -1,11 +1,12 @@
 using System.Windows.Controls;
 using Nuform.App.ViewModels;
+using VmEstimateState = Nuform.App.ViewModels.EstimateState;
 
 namespace Nuform.App.Views
 {
     public partial class ResultsPage : Page
     {
-        public ResultsPage(EstimateState state)
+        public ResultsPage(VmEstimateState state)
         {
             InitializeComponent();
             DataContext = new ResultsViewModel(state);


### PR DESCRIPTION
## Summary
- use Domain enum aliases in IntakePage and view models to avoid name collisions
- drop LegacyCompat imports from app services and replace EstimateState references with view model alias

## Testing
- `dotnet build NuformEstimator.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acccbc49f48322acf7feea93ea9660