### PR TITLE
Fix missing core references in Nuform.App

### DIFF
--- a/Nuform.App/ExcelService.cs
+++ b/Nuform.App/ExcelService.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using Nuform.Core;
+using Nuform.Core.Domain;
+using CatalogItem = Nuform.Core.LegacyCompat.CatalogItem;
+using CatalogService = Nuform.Core.LegacyCompat.CatalogService;
 
 namespace Nuform.App;
 

--- a/Nuform.App/GlobalUsings.cs
+++ b/Nuform.App/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using Nuform.Core;
+global using Nuform.Core.Domain;
+global using Nuform.Core.Services;
+global using Nuform.Core.Catalog;

--- a/Nuform.App/IntakePage.xaml.cs
+++ b/Nuform.App/IntakePage.xaml.cs
@@ -2,13 +2,13 @@ using System.Linq;
 using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
-using Nuform.Core;
 using Nuform.Core.Domain;
 using Nuform.App.ViewModels;
 using VmEstimateState = Nuform.App.ViewModels.EstimateState;
 using DomainCeilingOrientation = Nuform.Core.Domain.CeilingOrientation;
 using DomainOpeningTreatment   = Nuform.Core.Domain.OpeningTreatment;
 using DomainNuformColor        = Nuform.Core.Domain.NuformColor;
+using Room = Nuform.Core.LegacyCompat.Room;
 
 namespace Nuform.App
 {

--- a/Nuform.App/Nuform.App.csproj
+++ b/Nuform.App/Nuform.App.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
-		<UseWPF>true</UseWPF>
-		<Nullable>enable</Nullable>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
   <ItemGroup>
         <ProjectReference Include="..\Nuform.Core\Nuform.Core.csproj" />

--- a/Nuform.App/SofGenerator.cs
+++ b/Nuform.App/SofGenerator.cs
@@ -4,6 +4,9 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Nuform.Core;
+using Nuform.Core.Domain;
+using CatalogItem = Nuform.Core.LegacyCompat.CatalogItem;
+using CatalogService = Nuform.Core.LegacyCompat.CatalogService;
 
 namespace Nuform.App;
 


### PR DESCRIPTION
## Summary
- add global usings and project settings for Core libraries
- update ExcelService, IntakePage, and SofGenerator to reference moved domain types

## Testing
- `dotnet build` *(fails: MSB4019 Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet build Nuform.Core/Nuform.Core.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68adbf908b6483228225dbbc092dc475